### PR TITLE
Workaround for data loss caused by non-utf8 data in payload

### DIFF
--- a/src/test/java/com/ubirch/protocol/ProtocolFixtures.java
+++ b/src/test/java/com/ubirch/protocol/ProtocolFixtures.java
@@ -56,6 +56,8 @@ public class ProtocolFixtures {
 	protected static String expectedSignedMessageJsonWithData;
 	protected static List<byte[]> expectedChainedMessages;
 	protected static List<String> expectedChainedMessagesJson;
+	protected static byte[] expectedSignedNonUtf8Message;
+	protected static byte[] expectedSignedNonUtf8Payload;
 
 	protected class TestProtocol extends Protocol {
 		private final Logger logger = LoggerFactory.getLogger(TestProtocol.class);
@@ -149,6 +151,9 @@ public class ProtocolFixtures {
 		expectedChainedMessagesJson.add(fixtures.getProperty("chainMessage01.json"));
 		expectedChainedMessagesJson.add(fixtures.getProperty("chaindMessage02.json"));
 		expectedChainedMessagesJson.add(fixtures.getProperty("chainMessage03.json"));
+
+		expectedSignedNonUtf8Message = Hex.decodeHex(fixtures.getProperty("nonUtf8Message").toCharArray());
+		expectedSignedNonUtf8Payload = Hex.decodeHex(fixtures.getProperty("nonUtf8Payload").toCharArray());
 	}
 
 	protected byte[] getBinaryFixture(String name) throws IOException {

--- a/src/test/java/com/ubirch/protocol/codec/MsgPackProtocolDecoderTest.java
+++ b/src/test/java/com/ubirch/protocol/codec/MsgPackProtocolDecoderTest.java
@@ -16,11 +16,13 @@
 
 package com.ubirch.protocol.codec;
 
+import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.ubirch.protocol.ProtocolException;
 import com.ubirch.protocol.ProtocolFixtures;
 import com.ubirch.protocol.ProtocolMessage;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
 import java.util.Arrays;
@@ -116,4 +118,11 @@ class MsgPackProtocolDecoderTest extends ProtocolFixtures {
 						decoder.decode(new byte[]{(byte) 0x91, 0x01}, (uuid, data, offset, len, signature) -> true));
 	}
 
+	@Test
+	void testMsgPackProtocolDecoderNonUtf8RawBinary() throws IOException {
+		ProtocolMessage message = MsgPackProtocolDecoder.getDecoder().decode(expectedSignedNonUtf8Message);
+
+		assertEquals(message.getPayload().getClass(), BinaryNode.class);
+		assertArrayEquals(message.getPayload().binaryValue(), expectedSignedNonUtf8Payload);
+	}
 }

--- a/src/test/resources/protocol_test.properties
+++ b/src/test/resources/protocol_test.properties
@@ -31,3 +31,6 @@ chainMessage03=9613b06eac4d0b16e645088c4622e7451ea5a1da0040da8777b72b80d9708e695
 chainMessage01.json={"chain":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==","hint":238,"payload":1,"signature":"YyC6ChlzkEOxL0oH98ytZz4ZOUEmE3uFlt3Ildy2X1/Pdp9BtSQvMScZKjUK6Y0berKHKR7LRYAwD7Ko+BBXCA==","uuid":"6eac4d0b-16e6-4508-8c46-22e7451ea5a1","version":19}
 chaindMessage02.json={"chain":"YyC6ChlzkEOxL0oH98ytZz4ZOUEmE3uFlt3Ildy2X1/Pdp9BtSQvMScZKjUK6Y0berKHKR7LRYAwD7Ko+BBXCA==","hint":238,"payload":2,"signature":"vWL1A0nvlDzoFiD85pKqi+ruFrZKsH33VVRhqe+wu0FoqqIq2rgbVXy4RLhLxDTQVRi2jhzdUm4fBVLds23AAA==","uuid":"6eac4d0b-16e6-4508-8c46-22e7451ea5a1","version":19}
 chainMessage03.json={"chain":"vWL1A0nvlDzoFiD85pKqi+ruFrZKsH33VVRhqe+wu0FoqqIq2rgbVXy4RLhLxDTQVRi2jhzdUm4fBVLds23AAA==","hint":238,"payload":3,"signature":"42qQaAwkKux38L0q1p6PCHA2Hf/bNPQkXK5m26JobollOBrR/OqxF7RV+SZVxx8uHCP+QExplm0++Lcf45KWAg==","uuid":"6eac4d0b-16e6-4508-8c46-22e7451ea5a1","version":19}
+# signed message with non-utf8 binary payload (the payload has msgpack v1 raw header!)
+nonUtf8Message=9512b07fc11b3c888c40fba595f98b3b10a66400b0736f6d6520627974657321000102039fda0040fac552193260880deb65bfa21923746a0f1c9172ff04c78ff2080ddb148ad7e23b6ef1b39c518124f20e9abe925de1cc8899acd5c7159cc4d50e111194a4ea05
+nonUtf8Payload=736f6d6520627974657321000102039f


### PR DESCRIPTION
Adds a workaround for data loss caused by non-utf8 data in msgpack messages where payload has a string header instead of binary header.