### PR TITLE
UP-2055 Adding method to extract the signed data and its signature an…

### DIFF
--- a/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolDecoder.java
+++ b/src/main/java/com/ubirch/protocol/codec/MsgPackProtocolDecoder.java
@@ -52,7 +52,7 @@ public class MsgPackProtocolDecoder extends ProtocolDecoder<byte[]> {
     }
 
     /**
-     * Decode a a protocol message from it's raw data.
+     * Decode a protocol message from it's raw data.
      *
      * @param message the raw protocol message in msgpack format
      * @return the decoded protocol message
@@ -115,6 +115,12 @@ public class MsgPackProtocolDecoder extends ProtocolDecoder<byte[]> {
         }
     }
 
+    /**
+     * Extracts the signed part and the signature out of the message pack without materializing.
+     * @param message the raw protocol message in msgpack format
+     * @return an array of arrays where the first element is the signed data and the second element is the signature.
+     * @throws ProtocolException if the fast extraction fails
+     */
     public byte[][] getDataToVerifyAndSignature(byte[] message) throws ProtocolException {
         ByteArrayInputStream in = new ByteArrayInputStream(message);
         MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(in);

--- a/src/test/java/com/ubirch/protocol/codec/MsgPackProtocolDecoderTest.java
+++ b/src/test/java/com/ubirch/protocol/codec/MsgPackProtocolDecoderTest.java
@@ -65,6 +65,16 @@ class MsgPackProtocolDecoderTest extends ProtocolFixtures {
     }
 
     @Test
+    void testMsgPackProtocolDecoderSignedMessageFromParts() throws ProtocolException {
+        ProtocolMessage pm = MsgPackProtocolDecoder.getDecoder().decode(expectedSignedMessage);
+        assertEquals(ProtocolMessage.SIGNED, pm.getVersion());
+        assertArrayEquals(expectedSimpleSignature, pm.getSignature());
+        byte[][] dataToVerifyAndSignature = MsgPackProtocolDecoder.getDecoder().getDataToVerifyAndSignature(expectedSignedMessage);
+        assertArrayEquals(pm.getSigned(), dataToVerifyAndSignature[0]);
+        assertArrayEquals(pm.getSignature(), dataToVerifyAndSignature[1]);
+    }
+
+    @Test
     void testMsgPackProtocolDecoderChainedMessage() throws ProtocolException {
         byte[] lastSignature = new byte[64];
         for (int i = 0; i < 3; i++) {
@@ -78,6 +88,20 @@ class MsgPackProtocolDecoderTest extends ProtocolFixtures {
             byte[] expectedSig = Arrays.copyOfRange(expectedMsg, expectedMsg.length - 64, expectedMsg.length);
             assertArrayEquals(expectedSig, pm.getSignature());
             lastSignature = expectedSig;
+        }
+    }
+
+    @Test
+    void testMsgPackProtocolDecoderChainedMessageFromParts() throws ProtocolException {
+        for (int i = 0; i < 3; i++) {
+            byte[] expectedMsg = expectedChainedMessages.get(i);
+            ProtocolMessage pm = MsgPackProtocolDecoder.getDecoder().decode(expectedMsg);
+            assertEquals(ProtocolMessage.CHAINED, pm.getVersion());
+            byte[] expectedSig = Arrays.copyOfRange(expectedMsg, expectedMsg.length - 64, expectedMsg.length);
+            assertArrayEquals(expectedSig, pm.getSignature());
+            byte[][] dataToVerifyAndSignature = MsgPackProtocolDecoder.getDecoder().getDataToVerifyAndSignature(expectedMsg);
+            assertArrayEquals(pm.getSigned(), dataToVerifyAndSignature[0]);
+            assertArrayEquals(pm.getSignature(), dataToVerifyAndSignature[1]);
         }
     }
 


### PR DESCRIPTION
Adding helper method to extract the signed part and signature without materializing. This is particularly useful if a pre-verification is required to be done before actually extracting all parts of the UPP.